### PR TITLE
add support sse writer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.22', '1.23']
+        go: ['1.23']
     name: Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/acoshift/arpc/v2
 
-go 1.22
+go 1.23
 
 require github.com/stretchr/testify v1.10.0
 

--- a/sse.go
+++ b/sse.go
@@ -1,0 +1,48 @@
+package arpc
+
+import "net/http"
+
+type SSEResponseWriter interface {
+	http.ResponseWriter
+	http.Flusher
+}
+
+var _ SSEResponseWriter = (*sseResponseWriter)(nil)
+
+type sseResponseWriter struct {
+	wrote bool
+	w     http.ResponseWriter
+}
+
+func newSSEResponseWriter(w http.ResponseWriter) SSEResponseWriter {
+	return &sseResponseWriter{w: w}
+}
+
+func (w *sseResponseWriter) writeHeader() {
+	if w.wrote {
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (w *sseResponseWriter) Header() http.Header {
+	return w.w.Header()
+}
+
+func (w *sseResponseWriter) WriteHeader(statusCode int) {
+	if w.wrote {
+		return
+	}
+	w.wrote = true
+	w.w.Header().Set("Content-Type", "text/event-stream")
+	w.w.WriteHeader(statusCode)
+}
+
+func (w *sseResponseWriter) Write(b []byte) (int, error) {
+	w.writeHeader()
+	return w.w.Write(b)
+}
+
+func (w *sseResponseWriter) Flush() {
+	w.w.(http.Flusher).Flush()
+}


### PR DESCRIPTION
Example

```go
func subscribe(ctx context.Context, w arpc.SSEResponseWriter) error {
    w.Write([]byte("data: hello\n\n"))
    w.Flush()
}
```